### PR TITLE
Add preferred fields to extend compatibility with Adobe fonts like Proxima Nova

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,7 +127,9 @@
       "wwsFamilyName",
       "wwsSubfamilyName",
       "lightPalette",
-      "darkPalette"
+      "darkPalette",
+      "preferredFamily",
+      "preferredSubfamily",
     ];
 
     var offset0 = offset;


### PR DESCRIPTION
Hello! This tool is so useful. Thank you for making it!

On my team we've noticed that many Adobe fonts, like Proxima Nova, store the true font family and subfamily values in `preferredFamily` and `preferredSubfamily` instead of the other existing fields. If you're okay with the addition, this would extend compatibility to those fonts.

Thank you again either way! This has been super helpful to my work. ✨ 